### PR TITLE
Treat dead Xalan-C as optional

### DIFF
--- a/modules/FindXmlSecurityC.cmake
+++ b/modules/FindXmlSecurityC.cmake
@@ -22,7 +22,7 @@ select_library_configurations(XmlSecurityC)
 mark_as_advanced(XmlSecurityC_INCLUDE_DIR XmlSecurityC_LIBRARY_RELEASE XmlSecurityC_LIBRARY_DEBUG)
 
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(XmlSecurityC DEFAULT_MSG XmlSecurityC_LIBRARY XmlSecurityC_INCLUDE_DIR XalanC_FOUND XercesC_FOUND OPENSSL_FOUND)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(XmlSecurityC DEFAULT_MSG XmlSecurityC_LIBRARY XmlSecurityC_INCLUDE_DIR XercesC_FOUND OPENSSL_FOUND)
 
 if(XmlSecurityC_FOUND)
   set(XmlSecurityC_INCLUDE_DIRS ${XmlSecurityC_INCLUDE_DIR} ${XercesC_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR})


### PR DESCRIPTION
Apache upstream stopped development, thus it will no longer receive
security updates.

All Xalan-C related code is already inside `if(XalanC_FOUND)`, so drop
the hard requirement.

OpenBSD has already removed its textproc/xalan-c port and currently
builds security/libdigidocpp with this patch, combined with the override
`-D CMAKE_DISABLE_FIND_PACKAGE_XalanC=ON` to ensure remaining
installations won't be used.

libdigidocpp's C++ code alread uses a feature guard and builds fine:
```
src/Container.cpp:#if XSEC_VERSION_MAJOR == 1 && !defined(XSEC_NO_XALAN) || defined(XSEC_HAVE_XALAN)
```
